### PR TITLE
Add security section

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -30,7 +30,7 @@
 <tbody>
 <tr>
 <th rowspan="2">
-<a href="http://xalan.apache.org/index.html">
+<a href="https://xalan.apache.org/index.html">
 <img alt="Trademark Logo" src="resources/Xalan-Logo-tm.png" width="190" height="90" />
 </a>
 </th>
@@ -47,19 +47,19 @@
 <tbody>
 <tr>
 <td>
-<a href="http://www.apache.org">Apache Foundation</a>
+<a href="https://www.apache.org">Apache Foundation</a>
 </td>
 <td>
-<a href="http://xalan.apache.org">Xalan Project</a>
+<a href="https://xalan.apache.org">Xalan Project</a>
 </td>
 <td>
-<a href="http://xerces.apache.org">Xerces Project</a>
+<a href="https://xerces.apache.org">Xerces Project</a>
 </td>
 <td>
-<a href="http://www.w3.org/TR">Web Consortium</a>
+<a href="https://www.w3.org/TR">Web Consortium</a>
 </td>
 <td>
-<a href="http://www.oasis-open.org/standards">Oasis Open</a>
+<a href="https://www.oasis-open.org/standards">Oasis Open</a>
 </td>
 </tr>
 </tbody>
@@ -73,7 +73,7 @@
 <li>Charter<br />
 </li>
 <li>
-<a href="http://wiki.apache.org/xalan">Xalan Wiki</a>
+<a href="https://wiki.apache.org/xalan">Xalan Wiki</a>
 </li></ul><hr /><ul></ul>
 <p class="navGroup">
 <em>Projects</em>
@@ -91,34 +91,34 @@
 <em>Mail Lists</em>
 </p><ul>
 <li>
-<a href="http://marc.info/?l=xalan-dev">Developers</a>
+<a href="https://marc.info/?l=xalan-dev">Developers</a>
 </li>
 <li>
-<a href="http://marc.info/?l=xalan-c-users">C Users</a>
+<a href="https://marc.info/?l=xalan-c-users">C Users</a>
 </li>
 <li>
-<a href="http://marc.info/?l=xalan-j-users">J Users</a>
+<a href="https://marc.info/?l=xalan-j-users">J Users</a>
 </li></ul><hr /><ul></ul>
 <p class="navGroup">
 <em>Resources</em>
 </p><ul>
 <li>
-<a href="http://www.apache.org/">Apache</a>
+<a href="https://www.apache.org/">Apache</a>
 </li>
 <li>
-<a href="http://www.apache.org/foundation/getinvolved.html">Get Involved</a>
+<a href="https://www.apache.org/foundation/getinvolved.html">Get Involved</a>
 </li>
 <li>
-<a href="http://www.apache.org/licenses/">Licenses</a>
+<a href="https://www.apache.org/licenses/">Licenses</a>
 </li>
 <li>
-<a href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a>
+<a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a>
 </li>
 <li>
-<a href="http://www.apache.org/foundation/thanks.html">Thanks</a>
+<a href="https://www.apache.org/foundation/thanks.html">Thanks</a>
 </li>
 <li>
-<a href="http://www.apache.org/security/">Security</a>
+<a href="/index.html#Security">Security</a>
 </li></ul><hr /><ul></ul>
 </div>
 <div id="content">
@@ -468,7 +468,7 @@
 <a href="#content">(top)</a>
 </p>
 </div>
-<div id="footer">Copyright © 1999-2014 The Apache Software Foundation<br />Apache, Xalan, and the Feather logo are trademarks of The Apache Software Foundation<div class="small">Web Page created on - Sun 2020-06-07</div>
+<div id="footer">Copyright © 1999-2023 The Apache Software Foundation<br />Apache, Xalan, and the Feather logo are trademarks of The Apache Software Foundation<div class="small">Web Page created on - Sat 2023-01-21</div>
 </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 <tbody>
 <tr>
 <th rowspan="2">
-<a href="http://xalan.apache.org/index.html">
+<a href="https://xalan.apache.org/index.html">
 <img alt="Trademark Logo" src="resources/Xalan-Logo-tm.png" width="190" height="90" />
 </a>
 </th>
@@ -47,19 +47,19 @@
 <tbody>
 <tr>
 <td>
-<a href="http://www.apache.org">Apache Foundation</a>
+<a href="https://www.apache.org">Apache Foundation</a>
 </td>
 <td>
-<a href="http://xalan.apache.org">Xalan Project</a>
+<a href="https://xalan.apache.org">Xalan Project</a>
 </td>
 <td>
-<a href="http://xerces.apache.org">Xerces Project</a>
+<a href="https://xerces.apache.org">Xerces Project</a>
 </td>
 <td>
-<a href="http://www.w3.org/TR">Web Consortium</a>
+<a href="https://www.w3.org/TR">Web Consortium</a>
 </td>
 <td>
-<a href="http://www.oasis-open.org/standards">Oasis Open</a>
+<a href="https://www.oasis-open.org/standards">Oasis Open</a>
 </td>
 </tr>
 </tbody>
@@ -73,7 +73,7 @@
 <a href="charter.html">Charter</a>
 </li>
 <li>
-<a href="http://wiki.apache.org/xalan">Xalan Wiki</a>
+<a href="https://wiki.apache.org/xalan">Xalan Wiki</a>
 </li></ul><hr /><ul></ul>
 <p class="navGroup">
 <em>Projects</em>
@@ -91,34 +91,34 @@
 <em>Mail Lists</em>
 </p><ul>
 <li>
-<a href="http://marc.info/?l=xalan-dev">Developers</a>
+<a href="https://marc.info/?l=xalan-dev">Developers</a>
 </li>
 <li>
-<a href="http://marc.info/?l=xalan-c-users">C Users</a>
+<a href="https://marc.info/?l=xalan-c-users">C Users</a>
 </li>
 <li>
-<a href="http://marc.info/?l=xalan-j-users">J Users</a>
+<a href="https://marc.info/?l=xalan-j-users">J Users</a>
 </li></ul><hr /><ul></ul>
 <p class="navGroup">
 <em>Resources</em>
 </p><ul>
 <li>
-<a href="http://www.apache.org/">Apache</a>
+<a href="https://www.apache.org/">Apache</a>
 </li>
 <li>
-<a href="http://www.apache.org/foundation/getinvolved.html">Get Involved</a>
+<a href="https://www.apache.org/foundation/getinvolved.html">Get Involved</a>
 </li>
 <li>
-<a href="http://www.apache.org/licenses/">Licenses</a>
+<a href="https://www.apache.org/licenses/">Licenses</a>
 </li>
 <li>
-<a href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a>
+<a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a>
 </li>
 <li>
-<a href="http://www.apache.org/foundation/thanks.html">Thanks</a>
+<a href="https://www.apache.org/foundation/thanks.html">Thanks</a>
 </li>
 <li>
-<a href="http://www.apache.org/security/">Security</a>
+<a href="/index.html#Security">Security</a>
 </li></ul><hr /><ul></ul>
 </div>
 <div id="content">
@@ -296,12 +296,23 @@ for general user comments on the Xalan Java project.</p>
  <a href="http://www.apache.org/foundation/getinvolved.html">how to 
 participate</a> in the various development efforts.</p>
 
+<a name="Security">‌</a>
+<p align="right" size="2">
+<a href="#content">(top)</a>
+</p>
+<h3>Security</h3>
+<p>Xerces and Xalan do what the XML specifications require by default. In some cases, this may not be appropriate behavior when working with untrusted input: the <a href="https://apache.github.io/xalan-c/secureweb.html">XML Security Overview</a> mentions some potential risks. There are multiple methods for blocking access to external entities and for disallowing DOCTYPE declarations, and it is up to the downstream user of Xalan to block/reject these constructs where appropriate.</p>
+
+<p>If you think you have found a security issue in Apache Xalan, please follow the <a href="https://www.apache.org/security/#reporting-a-vulnerability">reporting guidelines</a>
+</p>
+
+
 
 <p align="right" size="2">
 <a href="#content">(top)</a>
 </p>
 </div>
-<div id="footer">Copyright © 1999-2014 The Apache Software Foundation<br />Apache, Xalan, and the Feather logo are trademarks of The Apache Software Foundation<div class="small">Web Page created on - Sun 2020-06-07</div>
+<div id="footer">Copyright © 1999-2023 The Apache Software Foundation<br />Apache, Xalan, and the Feather logo are trademarks of The Apache Software Foundation<div class="small">Web Page created on - Sat 2023-01-21</div>
 </div>
 </body>
 </html>

--- a/xdocs/sources/make-xalan-org.sh
+++ b/xdocs/sources/make-xalan-org.sh
@@ -103,7 +103,7 @@ XALANLOGOWIDTH=190
 
 XALANLOGOHEIGHT=90
 
-XALANLOGOLINK=http://xalan.apache.org/index.html
+XALANLOGOLINK=https://xalan.apache.org/index.html
 
 XALANTITLELINK=index.html
 

--- a/xdocs/sources/stylebook.xslt
+++ b/xdocs/sources/stylebook.xslt
@@ -35,7 +35,7 @@
 <!-- THE TOP-LEVEL PARAMETERS 
 
   logoimage   = resource image for active logo (resources/asf_logo.png)
-  logolink    = logo active hyperlink          (http://xalan.apache.org)
+  logolink    = logo active hyperlink          (https://xalan.apache.org)
   logowidth   = width of trademark logo in pixels
   logoheight  = height of tracemark logo in pixels
 
@@ -53,7 +53,7 @@
 
   EXSLT -p sectionid='getstarted' -p createdate='Aug 7, 2011'
     -p logoimage='resources/xalan-logo.png'
-    -p logolink='http://xalan.apache.org'
+    -p logolink='https://xalan.apache.org'
     -p logowidth='144'
     -p logoheight='75'
     -p bookxml='xalan.xml'
@@ -62,7 +62,7 @@
 -->
 
 <xsl:param name="logoimage">resources/asf_logo.png</xsl:param>
-<xsl:param name="logolink">http://www.apache.org</xsl:param>
+<xsl:param name="logolink">https://www.apache.org</xsl:param>
 <xsl:param name="logowidth">144</xsl:param>
 <xsl:param name="logoheight">75</xsl:param>
 
@@ -228,7 +228,7 @@
   <xsl:param name="headtitlelink">index.html</xsl:param>
   <xsl:param name="headsubtitle">Documentation Test Example</xsl:param>
   <xsl:param name="headlogoimg">resources/asf_logo.png</xsl:param>
-  <xsl:param name="headlogolink">http://www.apache.org</xsl:param>
+  <xsl:param name="headlogolink">https://www.apache.org</xsl:param>
   <xsl:param name="headlogoheight"><xsl:value-of select="$logoheight"/></xsl:param>
   <xsl:param name="headlogowidth"><xsl:value-of select="$logowidth"/></xsl:param>
   <xsl:element name="div">
@@ -273,11 +273,11 @@
     <table class="HdrButtons" align="center" border="1">
      <tbody>
       <tr>
-       <td><a href="http://www.apache.org">Apache Foundation</a></td>
-       <td><a href="http://xalan.apache.org">Xalan Project</a></td>
-       <td><a href="http://xerces.apache.org">Xerces Project</a></td>
-       <td><a href="http://www.w3.org/TR">Web Consortium</a></td>
-       <td><a href="http://www.oasis-open.org/standards">Oasis Open</a></td>
+       <td><a href="https://www.apache.org">Apache Foundation</a></td>
+       <td><a href="https://xalan.apache.org">Xalan Project</a></td>
+       <td><a href="https://xerces.apache.org">Xerces Project</a></td>
+       <td><a href="https://www.w3.org/TR">Web Consortium</a></td>
+       <td><a href="https://www.oasis-open.org/standards">Oasis Open</a></td>
       </tr>
      </tbody>
     </table>
@@ -469,7 +469,7 @@
     <xsl:attribute name="id">footer</xsl:attribute>
     <!-- copyright byline information -->
     <!-- &#169; is the (c) copyright symbol -->
-    <xsl:text>Copyright &#169; 1999-2014 The Apache Software Foundation</xsl:text><br/>
+    <xsl:text>Copyright &#169; 1999-2023 The Apache Software Foundation</xsl:text><br/>
     <xsl:text>Apache, Xalan, and the Feather logo are trademarks of The Apache Software Foundation</xsl:text>
     <xsl:element name="div">
       <xsl:attribute name="class">small</xsl:attribute>

--- a/xdocs/sources/xalan-apache-org-site.xml
+++ b/xdocs/sources/xalan-apache-org-site.xml
@@ -20,7 +20,7 @@
 <book title="Apache Xalan Project " copyright="2014 The Apache Software Foundation">
   <document id="index" label="Apache Xalan" source="xalan-apache-org/index.xml"/>
   <document id="charter" label="Charter" source="xalan-apache-org/charter.xml"/>
-  <external href="http://wiki.apache.org/xalan" label = "Xalan Wiki"/>
+  <external href="https://wiki.apache.org/xalan" label = "Xalan Wiki"/>
   <separator/>  
 <!--
   <external href="http://xml.apache.org/xalan-c" label="Xalan C++"/>  
@@ -33,18 +33,18 @@
 </group>
   <separator/>
 <group label="Mail Lists">
-  <external href="http://marc.info/?l=xalan-dev" label="Developers"/>
-  <external href="http://marc.info/?l=xalan-c-users" label="C Users"/>
-  <external href="http://marc.info/?l=xalan-j-users" label="J Users"/>
+  <external href="https://marc.info/?l=xalan-dev" label="Developers"/>
+  <external href="https://marc.info/?l=xalan-c-users" label="C Users"/>
+  <external href="https://marc.info/?l=xalan-j-users" label="J Users"/>
 </group>
   <separator/>
 <group label="Resources">
-  <external href="http://www.apache.org/" label="Apache"/>
-  <external href="http://www.apache.org/foundation/getinvolved.html" label="Get Involved"/>
-  <external href="http://www.apache.org/licenses/" label="Licenses"/>
-  <external href="http://www.apache.org/foundation/sponsorship.html" label="Sponsorship"/>
-  <external href="http://www.apache.org/foundation/thanks.html" label="Thanks"/>
-  <external href="http://www.apache.org/security/" label="Security"/>
+  <external href="https://www.apache.org/" label="Apache"/>
+  <external href="https://www.apache.org/foundation/getinvolved.html" label="Get Involved"/>
+  <external href="https://www.apache.org/licenses/" label="Licenses"/>
+  <external href="https://www.apache.org/foundation/sponsorship.html" label="Sponsorship"/>
+  <external href="https://www.apache.org/foundation/thanks.html" label="Thanks"/>
+  <external href="/index.html#Security" label="Security"/>
 </group>
   <separator/>
 </book>

--- a/xdocs/sources/xalan-apache-org/index.xml
+++ b/xdocs/sources/xalan-apache-org/index.xml
@@ -160,5 +160,12 @@ for general user comments on the Xalan Java project.</p>
  <jump href="http://www.apache.org/foundation/getinvolved.html">how to 
 participate</jump> in the various development efforts.</p>
 </s2>
+<anchor name="Security"/>
+<s2 title="Security">
+<p>Xerces and Xalan do what the XML specifications require by default. In some cases, this may not be appropriate behavior when working with untrusted input: the <jump href="https://apache.github.io/xalan-c/secureweb.html">XML Security Overview</jump> mentions some potential risks. There are multiple methods for blocking access to external entities and for disallowing DOCTYPE declarations, and it is up to the downstream user of Xalan to block/reject these constructs where appropriate.</p>
+
+<p>If you think you have found a security issue in Apache Xalan, please follow the <jump href="https://www.apache.org/security/#reporting-a-vulnerability">reporting guidelines</jump></p>
+
+</s2>
 
 </s1>


### PR DESCRIPTION
It seems people occasionally don't realize they should expect to take some precautions before using Xalan on untrusted input. It might be good to make an explicit note about that on the website, something like the attached patch?

Of course it would be even better if we could provide (or link to) in-depth instructions, but until we have something like that I think just highlighting the fact that this needs people's attention would be an improvement.